### PR TITLE
Add start tomcat server functionality. and fix issue no java debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "view/item/context": [
         {
           "command": "tomcat.start",
-          "when": "view == tomcatServerExplorer && viewItem != runningserver"
+          "when": "view == tomcatServerExplorer && viewItem == tomcatserver"
         },
         {
           "command": "tomcat.stop",
@@ -99,7 +99,7 @@
         },
         {
           "command": "tomcat.delete",
-          "when": "view == tomcatServerExplorer && viewItem != runningserver"
+          "when": "view == tomcatServerExplorer && viewItem == tomcatserver"
         },
         {
           "command": "tomcat.openconfig",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "onCommand:tomcat.stop",
     "onCommand:tomcat.delete",
     "onCommand:tomcat.openconfig",
+    "onCommand:tomcat.start",
     "onView:tomcatServerExplorer"
   ],
   "main": "./out/src/extension",
@@ -56,6 +57,10 @@
       {
         "command": "tomcat.openconfig",
         "title": "Open server.xml"
+      },
+      {
+        "command": "tomcat.start",
+        "title": "Start Tomcat Server"
       }
     ],
     "views": {
@@ -84,6 +89,10 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "tomcat.start",
+          "when": "view == tomcatServerExplorer && viewItem != runningserver"
+        },
         {
           "command": "tomcat.stop",
           "when": "view == tomcatServerExplorer && viewItem == runningserver"

--- a/resources/index.jsp
+++ b/resources/index.jsp
@@ -1,0 +1,27 @@
+<html>
+<meta charset="UTF-8"><title>Apache Tomcat</title></head>
+<body>
+	<p><h3>Deployed Packages</h3><p></p>
+<%@ page import="java.io.*" %>
+<% 
+	String file = application.getRealPath("/");
+%>
+	<ul>
+<%
+	File f = new File(file);
+	String webappsPath = f.getParent();
+	File webapps = new File(webappsPath);
+	String [] fileNames = webapps.list();
+	File [] fileObjects= webapps.listFiles();
+	for (int i = 0; i < fileObjects.length; i++) {
+	if(fileObjects[i].isDirectory() && !("ROOT").equalsIgnoreCase(fileNames[i])){
+		String fname = file+fileNames[i];
+%>
+		<li><a href="<%= fileNames[i] %>"><%= fileNames[i] %></a></li>
+<%
+	}
+	}
+%>
+	</ul>
+</body>
+</html>

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -98,7 +98,7 @@ export class TomcatController {
         }
 
         try {
-            await Utility.executeCMD('java', this.getJavaArgs(serverInfo, false), {shell: true}, this.getOutput(serverInfo));
+            await Utility.executeCMD(this.getOutput(serverInfo), 'java', {shell: true}, ...this.getJavaArgs(serverInfo, false));
             return Promise.resolve();
         } catch (err) {
             return Promise.reject(new Error(err.toString()));
@@ -167,7 +167,7 @@ export class TomcatController {
         const serverName: string = serverInfo.getName();
         const appPath: string = path.join(this._tomcat.getExtensionPath(), serverName, 'webapps', appName);
         await Utility.cleanAndCreateFolder(appPath);
-        await Utility.executeCMD('jar', ['xvf', `${packagePath}`], {cwd: appPath}, output);
+        await Utility.executeCMD(output, 'jar', {cwd: appPath}, 'xvf', `${packagePath}`);
         return appName;
     }
 
@@ -246,7 +246,7 @@ export class TomcatController {
             }
 
             this.setStarted(serverInfo, true);
-            const javaProcss: Promise<void> = Utility.executeCMD('java', args, { shell: true }, output);
+            const javaProcss: Promise<void> = Utility.executeCMD(output, 'java', { shell: true }, ...args);
             this.startDebugSession(debugPort, workspaceFolder);
             await javaProcss;
             this.setStarted(serverInfo, false);

--- a/src/Tomcat/TomcatServer.ts
+++ b/src/Tomcat/TomcatServer.ts
@@ -35,4 +35,12 @@ export class TomcatServer {
     public getServerConfigPath(): string {
         return path.join(this._extensionPath, this._name, 'conf', 'server.xml');
     }
+
+    public getRootDeployPath(): string {
+        return path.join(this.getWebAppPath(), 'ROOT');
+    }
+
+    public getWebAppPath(): string {
+        return path.join(this._extensionPath, this._name, 'webapps');
+    }
 }

--- a/src/Tomcat/TomcatServer.ts
+++ b/src/Tomcat/TomcatServer.ts
@@ -35,12 +35,4 @@ export class TomcatServer {
     public getServerConfigPath(): string {
         return path.join(this._extensionPath, this._name, 'conf', 'server.xml');
     }
-
-    public getRootDeployPath(): string {
-        return path.join(this.getWebAppPath(), 'ROOT');
-    }
-
-    public getWebAppPath(): string {
-        return path.join(this._extensionPath, this._name, 'webapps');
-    }
 }

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -10,8 +10,8 @@ import * as xml2js from "xml2js";
 import { TomcatServer } from "./Tomcat/TomcatServer";
 
 export namespace Utility {
-    export async function executeCMD(command: string, args: string[],
-                                     options: child_process.SpawnOptions, outputPane: vscode.OutputChannel): Promise<void> {
+    export async function executeCMD(outputPane: vscode.OutputChannel, command: string,
+                                     options: child_process.SpawnOptions, ...args: string[]): Promise<void> {
         await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
             outputPane.show();
             let stderr: string = '';

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -141,45 +141,7 @@ export namespace Utility {
         return finalHtml;
     }
 
-    export async function writeFile(filePath: string, content: string): Promise<void> {
-        if (await fse.pathExists(filePath)) {
-            await fse.remove(filePath);
-        }
-        await fse.writeFile(filePath, content);
-    }
-
-    export async function getSubDirs(dir: string): Promise<string[]> {
-        const isDir: boolean = await isDirectory(dir);
-        if (!isDir) {
-            return [];
-        }
-
-        return await new Promise((resolve: (obj: string[]) => void, reject: (e: Error) => void): void => {
-            fse.readdir(dir, (err: NodeJS.ErrnoException, files: string[]) => {
-                if (err) {
-                    return reject(new Error(err.toString()));
-                } else {
-                    const subFolders: string[] = files.filter(async (name: string) =>
-                                                                await isDirectory(path.join(dir, name)));
-                    resolve(subFolders);
-                }
-            });
-        });
-    }
-
     export const localize: nls.LocalizeFunc = nls.config(process.env.VSCODE_NLS_CONFIG)();
-
-    async function isDirectory(filePath: string): Promise<boolean> {
-        return await new Promise((resolve: (obj: boolean) => void, reject: (e: Error) => void): void => {
-            fse.lstat(filePath, (err: NodeJS.ErrnoException, state: fse.Stats) => {
-                if (err) {
-                    return reject(new Error(err.toString()));
-                } else {
-                    return resolve(state.isDirectory());
-                }
-            });
-        });
-    }
 
     async function parseXml(xml: string): Promise<{}> {
         return new Promise((resolve: (obj: {}) => void, reject: (e: Error) => void): void => {

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -130,17 +130,6 @@ export namespace Utility {
         }
     }
 
-    export function generateRootPageString(packages: string[]): string {
-        const htmlPart1: string = '<html><meta charset="UTF-8"><title>Apache Tomcat</title></head><body><p><h3>Deployed Packages</h3><p></p><ul>';
-        const htmlPart2: string = '</ul></body></html>';
-        let finalHtml: string = htmlPart1;
-        packages.forEach((packageName: string) => {
-            finalHtml = finalHtml.concat(`<li><a href="${packageName}">${packageName}</a></li>`);
-        });
-        finalHtml = finalHtml.concat(htmlPart2);
-        return finalHtml;
-    }
-
     export const localize: nls.LocalizeFunc = nls.config(process.env.VSCODE_NLS_CONFIG)();
 
     async function parseXml(xml: string): Promise<{}> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Tomcat');
     const tomcatData: Tomcat = new Tomcat(storagePath);
     const tree: TomcatSeverTreeProvider = new TomcatSeverTreeProvider(context, tomcatData);
-    const tomcat: TomcatController = new TomcatController(tomcatData, tree._onDidChangeTreeData);
+    const tomcat: TomcatController = new TomcatController(tomcatData, context.extensionPath, tree._onDidChangeTreeData);
 
     context.subscriptions.push(tomcat);
     context.subscriptions.push(tree);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ export function activate(context: vscode.ExtensionContext): void {
     initCommand(context, outputChannel, tomcat, 'tomcat.stop', serverStop);
     initCommand(context, outputChannel, tomcat, 'tomcat.delete', serverDelete);
     initCommand(context, outputChannel, tomcat, 'tomcat.openconfig', serverOpenConfig);
+    initCommand(context, outputChannel, tomcat, 'tomcat.start', serverStart);
 }
 
 function initCommand<T>(context: vscode.ExtensionContext, output: vscode.OutputChannel, tomcat: TomcatController,
@@ -79,6 +80,13 @@ async function getTargetServer(tomcat: TomcatController, tomcatItem ?: TomcatSer
     }
 }
 
+async function serverStart(tomcat: TomcatController, tomcatItem ?: TomcatServer): Promise<void> {
+    const server: TomcatServer = await getTargetServer(tomcat, tomcatItem);
+    if (server) {
+        await tomcat.startServer(server);
+    }
+}
+
 async function serverStop(tomcat: TomcatController, tomcatItem ?: TomcatServer): Promise<void> {
     const server: TomcatServer = await getTargetServer(tomcat, tomcatItem);
     if (server) {
@@ -115,11 +123,11 @@ async function createServer(tomcat: TomcatController): Promise<string> {
 }
 
 async function serverDebug(tomcat: TomcatController, uri?: vscode.Uri): Promise<void> {
-    await startTomcat(tomcat, true, uri);
+    await runOnTomcat(tomcat, true, uri);
 }
 
 async function serverRun(tomcat: TomcatController, uri?: vscode.Uri): Promise<void> {
-    await startTomcat(tomcat, false, uri);
+    await runOnTomcat(tomcat, false, uri);
 }
 
 async function selectFile(ui: VSCodeUI, placehoder: string): Promise<string> {
@@ -164,7 +172,7 @@ async function selectOrCreateServer(ui: VSCodeUI, placeholder: string,
     return serverPick && serverPick !== newServer ? serverPick : await createServer(tomcat);
 }
 
-async function startTomcat(tomcat: TomcatController, debug: boolean, uri?: vscode.Uri): Promise<void> {
+async function runOnTomcat(tomcat: TomcatController, debug: boolean, uri?: vscode.Uri): Promise<void> {
     const inputPath: vscode.Uri | undefined = uri ? uri : undefined;
     const ui: VSCodeUI = new VSCodeUI();
     const packagePath: string = inputPath ? inputPath.fsPath

--- a/test/Tomcat.test.ts
+++ b/test/Tomcat.test.ts
@@ -6,7 +6,7 @@ import { Utility } from "../src/Utility";
 
 suite('Error input', () => {
   const serverInfo: TomcatServer = undefined;
-  const tomcat: TomcatController = new TomcatController(new Tomcat(''), undefined);
+  const tomcat: TomcatController = new TomcatController(new Tomcat(''), undefined, undefined);
   test('stopServer', async () => {
     try {
       await tomcat.stopServer(serverInfo);


### PR DESCRIPTION
1. Add start tomcat server command. No war package is needed to start tomcat. And a root jsp will be created to show the deployed package link.
2. Fix the issue when java debugger is not installed. The issue happens when java debugger is not installed, and debug tomcat, the server will be suspended and cannot be stopped. Except kill process from command line. To fix the issue, instead of use suspend=y, change to n. And the server will not be hung any more.
