### PR TITLE
Fix #22 solve the conflict issue between tomcat start sessions

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -14,5 +14,5 @@
   "tomcatExt.noconfig": "The tomcat server is broken. It does not have server.xml",
   "tomcatExt.open": "Open {0}.",
   "tomcatExt.confchanged": "server.xml of running {0} has been changed. Would you like to restart it?",
-  "tomcatExt.restartfail": "Restart {0} failed"
+  "tomcatExt.failstop": "Failed to stop {0}"
 }


### PR DESCRIPTION
The root cause is during restart the new session compete with the old session. So move the start the logic after the old session ends