### PR TITLE
remove duplicate wrap in extension, update context command title

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
       },
       {
         "command": "tomcat.server.create",
-        "title": "New Tomcat Server",
+        "title": "Create Tomcat Server",
         "category": "Tomcat",
         "icon": {
           "light": "resources/light/add.svg",
@@ -82,7 +82,7 @@
       },
       {
         "command": "tomcat.config.open",
-        "title": "Open server.xml",
+        "title": "open server config",
         "category": "Tomcat"
       },
       {
@@ -102,8 +102,32 @@
       },
       {
         "command": "tomcat.server.browse",
-        "title": "Open in Browser",
+        "title": "browse",
         "category": "Tomcat"
+      },
+      {
+        "command": "tomcat.server.delete.context",
+        "title": "delete"
+      },
+      {
+        "command": "tomcat.server.start.context",
+        "title": "start"
+      },
+      {
+        "command": "tomcat.server.restart.context",
+        "title": "restart"
+      },
+      {
+        "command": "tomcat.server.rename.context",
+        "title": "rename"
+      },
+      {
+        "command": "tomcat.server.stop.context",
+        "title": "stop"
+      },
+      {
+        "command": "tomcat.war.browse",
+        "title": "browse"
       }
     ],
     "views": {
@@ -137,11 +161,31 @@
           "when": "false == true"
         },
         {
-          "command": "tomcat.server.rename",
+          "command": "tomcat.config.open",
           "when": "false == true"
         },
         {
           "command": "tomcat.war.browse",
+          "when": "false == true"
+        },
+        {
+          "command": "tomcat.server.start.context",
+          "when": "false == true"
+        },
+        {
+          "command": "tomcat.server.restart.context",
+          "when": "false == true"
+        },
+        {
+          "command": "tomcat.server.rename.context",
+          "when": "false == true"
+        },
+        {
+          "command": "tomcat.server.delete.context",
+          "when": "false == true"
+        },
+        {
+          "command": "tomcat.server.stop.context",
           "when": "false == true"
         }
       ],
@@ -157,17 +201,17 @@
       ],
       "view/item/context": [
         {
-          "command": "tomcat.server.start",
+          "command": "tomcat.server.start.context",
           "when": "view == tomcatServerExplorer && viewItem == idleserver",
           "group": "tomcat@0"
         },
         {
-          "command": "tomcat.server.stop",
+          "command": "tomcat.server.stop.context",
           "when": "view == tomcatServerExplorer && viewItem == runningserver",
           "group": "tomcat@1"
         },
         {
-          "command": "tomcat.server.restart",
+          "command": "tomcat.server.restart.context",
           "when": "view == tomcatServerExplorer && viewItem == runningserver",
           "group": "tomcat@2"
         },
@@ -177,28 +221,18 @@
           "group": "tomcat@3"
         },
         {
-          "command": "tomcat.server.rename",
+          "command": "tomcat.server.rename.context",
           "when": "view == tomcatServerExplorer && viewItem && viewItem != war",
           "group": "tomcat@4"
         },
         {
-          "command": "tomcat.config.open",
-          "when": "view == tomcatServerExplorer && viewItem == runningserver",
+          "command": "tomcat.server.delete.context",
+          "when": "view == tomcatServerExplorer && viewItem && viewItem != war",
           "group": "tomcat@5"
         },
         {
           "command": "tomcat.config.open",
-          "when": "view == tomcatServerExplorer && viewItem == idleserver",
-          "group": "tomcat@5"
-        },
-        {
-          "command": "tomcat.server.delete",
-          "when": "view == tomcatServerExplorer && viewItem == runningserver",
-          "group": "tomcat@6"
-        },
-        {
-          "command": "tomcat.server.delete",
-          "when": "view == tomcatServerExplorer && viewItem == idleserver",
+          "when": "view == tomcatServerExplorer && viewItem && viewItem != war",
           "group": "tomcat@6"
         },
         {

--- a/src/DialogMessage.ts
+++ b/src/DialogMessage.ts
@@ -8,11 +8,10 @@ export namespace DialogMessage {
     export const no: MessageItem = { title: localize('tomcatExt.no', 'No'), isCloseAffordance: true };
     export const cancel: MessageItem = { title: localize('tomcatExt.cancel', 'Cancel'), isCloseAffordance: true };
     export const never: MessageItem = { title: localize('tomcatExt.never', 'Never') };
-    export const moreInfo: MessageItem = { title: localize('tomcatExt.more', 'More Info') };
+    export const moreInfo: MessageItem = { title: localize('tomcatExt.moreInfo', 'More Info') };
     export const selectServer: string = localize('tomcatExt.selectServer', 'Select Tomcat Server');
     export const createServer: string = localize('tomcatExt.createServer', 'Create New Server');
     export const noServer: string = localize('tomcatExt.noServer', 'There are no Tomcat Servers.');
-    export const serverExist: string = localize('tomcatExt.serverExist', 'This Tomcat Server already exists, abort creation.');
     export const noPackage: string = localize('tomcatExt.noPackage', 'The selected package is not under current workspace.');
     export const noServerConfig: string = localize('tomcatExt.noServerConfig', 'The Tomcat Server is broken. It does not have server.xml');
     export const selectWarPackage: string = localize('tomcatExt.selectWarPackage', 'Select War Package');
@@ -20,17 +19,12 @@ export namespace DialogMessage {
     export const deleteConfirm: string = localize('tomcatExt.deleteConfirm', 'This Tomcat Server is running, are you sure you want to delete it?');
     export const serverRunning: string = localize('tomcatExt.serverRunning', 'This Tomcat Server is already started.');
     export const serverStopped: string = localize('tomcatExt.serverStopped', 'This Tomcat Server was stopped.');
-    export const continueOnExistingServer: string = localize('tomcatExt.continueOnExistingServer', 'This Tomcat Server already exists. Do you want to continue the operation on this server?');
-    export const startServerToBrowseWarPackage: string = localize('tomcatExt.startServerToBrowseWarPackage', 'Start Tomcat Server to browse the war package');
+    export const startServer: string = localize('tomcatExt.startServer', 'Would you like to start Tomcat Server first to browse the war package?');
 
     export function getServerPortChangeErrorMessage(serverName: string, serverPort: string): string {
         return localize('tomcatExt.serverPortChangeError', 'Changing the server port of a running server {0} will cause it unable to shutdown. Would you like to change it back to {1}?', serverName, serverPort);
     }
     export function getConfigChangedMessage(serverName: string): string {
         return localize('tomcatExt.configChanged', 'server.xml of running server {0} has been changed. Would you like to restart it?', serverName);
-    }
-
-    export function getStopFailureMessage(serverName: string): string {
-        return localize('tomcatExt.stopFailure', 'Failed to stop Tomcat Server {0}', serverName);
     }
 }

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -66,8 +66,9 @@ export class TomcatController {
             return;
         }
         const tomcatInstallPath: string = pathPick[0].fsPath;
-        if (!Utility.validateInstallPath(tomcatInstallPath)) {
-            throw new Error(Constants.INVALID_SERVER_DIRECTORY);
+        if (!await Utility.validateInstallPath(tomcatInstallPath)) {
+            vscode.window.showErrorMessage(Constants.INVALID_SERVER_DIRECTORY);
+            return;
         }
         const serverName: string = await Utility.getServerName(tomcatInstallPath, this._tomcatModel.defaultStoragePath);
         const catalinaBasePath: string = await Utility.getServerStoragePath(this._tomcatModel.defaultStoragePath, serverName);

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -200,7 +200,7 @@ export class TomcatController {
         items = createIfNoneServer ? items.concat({ label: `$(plus) ${DialogMessage.createServer}`, description: '' }) : items;
         const pick: vscode.QuickPickItem = await vscode.window.showQuickPick(
             items,
-            { placeHolder: items && items.length > 0 ? DialogMessage.selectServer : DialogMessage.createServer }
+            { placeHolder: createIfNoneServer && items && items.length === 1 ? DialogMessage.createServer : DialogMessage.selectServer }
         );
 
         if (pick) {

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -2,8 +2,6 @@
 
 import * as chokidar from "chokidar";
 import * as fse from "fs-extra";
-// tslint:disable-next-line:no-require-imports
-import opn = require("opn");
 import * as path from "path";
 import * as portfinder from "portfinder";
 import * as vscode from "vscode";
@@ -19,74 +17,64 @@ export class TomcatController {
     constructor(private _tomcatModel: TomcatModel, private _extensionPath: string) {
     }
 
-    public getTomcatServer(serverName: string): TomcatServer {
-        return this._tomcatModel.getTomcatServer(serverName);
-    }
-
-    public getServerSet(): TomcatServer[] {
-        return this._tomcatModel.getServerSet();
-    }
-
     public async deleteServer(tomcatServer: TomcatServer): Promise<void> {
-        if (!tomcatServer) {
-            throw (new Error(DialogMessage.noServer));
-        }
-
-        if (tomcatServer.isStarted()) {
-            const confirmation: MessageItem = await vscode.window.showWarningMessage(DialogMessage.deleteConfirm, DialogMessage.yes, DialogMessage.cancel);
-            if (confirmation !== DialogMessage.yes) {
-                return;
+        const server: TomcatServer = await this.precheck(tomcatServer);
+        if (server) {
+            if (server.isStarted()) {
+                const confirmation: MessageItem = await vscode.window.showWarningMessage(DialogMessage.deleteConfirm, DialogMessage.yes, DialogMessage.cancel);
+                if (confirmation !== DialogMessage.yes) {
+                    return;
+                }
+                await this.stopOrRestartServer(server);
             }
-            await this.stopOrRestartServer(tomcatServer);
+            this._tomcatModel.deleteServer(server);
         }
-
-        if (this._tomcatModel.deleteServer(tomcatServer)) {
-            tomcatServer.outputChannel.dispose();
-        }
-        vscode.commands.executeCommand('tomcat.tree.refresh');
     }
 
-    public async openConfig(tomcatServer: TomcatServer): Promise<void> {
-        if (!tomcatServer) {
-            throw (new Error(DialogMessage.noServer));
+    public async openServerConfig(tomcatServer: TomcatServer): Promise<void> {
+        if (tomcatServer) {
+            const configFile: string = tomcatServer.getServerConfigPath();
+            if (!await fse.pathExists(configFile)) {
+                throw new Error(DialogMessage.noServerConfig);
+            }
+            vscode.window.showTextDocument(vscode.Uri.file(configFile), { preview: false });
         }
-
-        const configFile: string = tomcatServer.getServerConfigPath();
-        if (!await fse.pathExists(configFile)) {
-            throw new Error(DialogMessage.noServerConfig);
-        }
-        vscode.window.showTextDocument(vscode.Uri.file(configFile), { preview: false });
     }
 
     public async browseWarPackage(warPackage: WarPackage): Promise<void> {
         if (warPackage) {
             const server: TomcatServer = this._tomcatModel.getTomcatServer(warPackage.serverName);
-            opn(await this.getServerUri(server, warPackage.label));
+            const httpPort: string = await Utility.getPort(server.getServerConfigPath(), Constants.PortKind.Http);
             if (!server.isStarted()) {
-                const result: MessageItem = await vscode.window.showInformationMessage(DialogMessage.startServerToBrowseWarPackage, DialogMessage.yes, DialogMessage.no);
+                const result: MessageItem = await vscode.window.showInformationMessage(DialogMessage.startServer, DialogMessage.yes, DialogMessage.no);
                 if (result === DialogMessage.yes) {
                     this.startServer(server);
                 }
             }
+            Utility.browse(true, httpPort, warPackage.label);
         }
     }
 
-    public async createTomcatServer(tomcatInstallPath: string): Promise<string> {
-        const serverName: string = await Utility.getServerName(tomcatInstallPath, this._tomcatModel.defaultStoragePath);
-        const serverConfigFile: string = path.join(tomcatInstallPath, 'conf', 'server.xml');
-        const serverWebFile: string = path.join(tomcatInstallPath, 'conf', 'web.xml');
-        const serverBootstrapJarFile: string = path.join(tomcatInstallPath, 'bin', 'bootstrap.jar');
-        const serverJuliJarFile: string = path.join(tomcatInstallPath, 'bin', 'tomcat-juli.jar');
-
-        if (!await fse.pathExists(serverConfigFile) || !await fse.pathExists(serverWebFile) ||
-            !await fse.pathExists(serverBootstrapJarFile) || !await fse.pathExists(serverJuliJarFile)) {
+    public async createServer(): Promise<TomcatServer> {
+        const pathPick: vscode.Uri[] = await vscode.window.showOpenDialog({
+            defaultUri: vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined,
+            canSelectFiles: false,
+            canSelectFolders: true,
+            openLabel: DialogMessage.selectDirectory
+        });
+        if (!pathPick || pathPick.length <= 0 || !pathPick[0].fsPath) {
+            return;
+        }
+        const tomcatInstallPath: string = pathPick[0].fsPath;
+        if (!Utility.validateInstallPath(tomcatInstallPath)) {
             throw new Error(Constants.INVALID_SERVER_DIRECTORY);
         }
-        const catalinaBasePath: string = Utility.getServerStoragePath(this._tomcatModel.defaultStoragePath, serverName);
+        const serverName: string = await Utility.getServerName(tomcatInstallPath, this._tomcatModel.defaultStoragePath);
+        const catalinaBasePath: string = await Utility.getServerStoragePath(this._tomcatModel.defaultStoragePath, serverName);
         await fse.remove(catalinaBasePath);
         await Promise.all([
-            fse.copy(serverConfigFile, path.join(catalinaBasePath, 'conf', 'server.xml')),
-            fse.copy(serverWebFile, path.join(catalinaBasePath, 'conf', 'web.xml')),
+            fse.copy(path.join(tomcatInstallPath, 'conf', 'server.xml'), path.join(catalinaBasePath, 'conf', 'server.xml')),
+            fse.copy(path.join(tomcatInstallPath, 'conf', 'web.xml'), path.join(catalinaBasePath, 'conf', 'web.xml')),
             fse.copy(path.join(this._extensionPath, 'resources', 'index.jsp'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'index.jsp')),
             fse.copy(path.join(this._extensionPath, 'resources', 'icon.png'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'icon.png')),
             fse.mkdirs(path.join(catalinaBasePath, 'logs')),
@@ -95,67 +83,74 @@ export class TomcatController {
         ]);
         const tomcatServer: TomcatServer = new TomcatServer(serverName, tomcatInstallPath, catalinaBasePath);
         this._tomcatModel.addServer(tomcatServer);
-        vscode.commands.executeCommand('tomcat.tree.refresh');
-        return serverName;
+        return tomcatServer;
     }
 
-    public async renameServer(server: TomcatServer): Promise<void> {
-        const newName: string = await vscode.window.showInputBox({
-            prompt: 'input a new server name',
-            validateInput: (name: string): string => {
-                if (!name.match(/^[\w.-]+$/)) {
-                    return 'please input a valid server name';
-                } else if (this._tomcatModel.getTomcatServer(name)) {
-                    return 'the name was already taken, please re-input';
+    public async renameServer(tomcatServer: TomcatServer): Promise<void> {
+        const server: TomcatServer = await this.precheck(tomcatServer);
+        if (server) {
+            const newName: string = await vscode.window.showInputBox({
+                prompt: 'input a new server name',
+                validateInput: (name: string): string => {
+                    if (!name.match(/^[\w.-]+$/)) {
+                        return 'please input a valid server name';
+                    } else if (this._tomcatModel.getTomcatServer(name)) {
+                        return 'the name was already taken, please re-input';
+                    }
+                    return null;
                 }
-                return null;
+            });
+            if (newName) {
+                server.rename(newName);
+                await this._tomcatModel.saveServerList();
             }
-        });
-        if (!newName) {
+        }
+    }
+
+    public async stopOrRestartServer(tomcatServer: TomcatServer, restart: boolean = false): Promise<void> {
+        const server: TomcatServer = await this.precheck(tomcatServer);
+        if (server) {
+            if (!server.isStarted()) {
+                vscode.window.showInformationMessage(DialogMessage.serverStopped);
+                return;
+            }
+            await Utility.executeCMD(server.outputChannel, 'java', { shell: true }, ...this.getJavaArgs(server, false));
+            server.needRestart = restart;
+        }
+    }
+
+    public async startServer(tomcatServer: TomcatServer): Promise<void> {
+        const server: TomcatServer = tomcatServer ? tomcatServer : await this.selectServer(true);
+        if (server) {
+            if (server.isStarted()) {
+                vscode.window.showInformationMessage(DialogMessage.serverRunning);
+                return;
+            }
+            await this.startTomcat(server);
+        }
+    }
+
+    public async runOrDebugOnServer(uri?: vscode.Uri, debug?: boolean): Promise<void> {
+        if (!uri) {
+            const dialog: vscode.Uri[] = await vscode.window.showOpenDialog({
+                defaultUri: vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined,
+                canSelectFiles: true,
+                canSelectFolders: false,
+                openLabel: DialogMessage.selectWarPackage
+            });
+            if (!dialog || dialog.length <= 0 || !dialog[0].fsPath) {
+                return;
+            }
+            uri = dialog[0];
+        }
+
+        const packagePath: string = uri.fsPath;
+        const server: TomcatServer = await this.selectServer(true);
+        if (!server) {
             return;
         }
-        server.rename(newName);
-        await this._tomcatModel.saveServerList();
-        vscode.commands.executeCommand('tomcat.tree.refresh');
-    }
-
-    public async stopOrRestartServer(serverInfo: TomcatServer, restart: boolean = false): Promise<void> {
-        if (!serverInfo) {
-            throw new Error(DialogMessage.noServer);
-        }
-
-        await Utility.executeCMD(serverInfo.outputChannel, 'java', { shell: true }, ...this.getJavaArgs(serverInfo, false));
-        serverInfo.needRestart = restart;
-    }
-
-    public async startServer(serverInfo: TomcatServer): Promise<void> {
-        await this.run(serverInfo);
-    }
-
-    public async runOnServer(serverInfo: TomcatServer, packagePath: string, debug: boolean = false): Promise<void> {
-        await this.run(serverInfo, packagePath, debug);
-    }
-
-    public async openServer(serverInfo: TomcatServer): Promise<void> {
-        const serverUri: string = await this.getServerUri(serverInfo);
-        await opn(serverUri);
-    }
-
-    public dispose(): void {
-        this.stopServers();
-        this._tomcatModel.saveServerListSync();
-        this._tomcatModel.getServerSet().forEach((element: TomcatServer) => {
-           element.outputChannel.dispose();
-        });
-    }
-
-    private async run(serverInfo: TomcatServer, packagePath ?: string, debug ?: boolean): Promise<void> {
-        if (!serverInfo) {
-            throw new Error(DialogMessage.noServer);
-        }
-
-        const appName: string = packagePath ? await this.deployPackage(serverInfo, packagePath) : '';
-        if (serverInfo.isStarted() && ((!serverInfo.isDebugging() && !debug) ||  serverInfo.isDebugging() === debug)) {
+        await this.deployPackage(server, packagePath);
+        if (server.isStarted() && ((!server.isDebugging() && !debug) || server.isDebugging() === debug)) {
             return;
         }
         let port: number;
@@ -174,11 +169,46 @@ export class TomcatController {
             port = await portfinder.getPortPromise();
         }
 
-        serverInfo.setDebugInfo(debug, port, workspaceFolder);
-        if (serverInfo.isStarted()) {
-            await this.stopOrRestartServer(serverInfo, true);
+        server.setDebugInfo(debug, port, workspaceFolder);
+        if (server.isStarted()) {
+            await this.stopOrRestartServer(server, true);
         } else {
-            await this.startTomcat(serverInfo, appName);
+            await this.startTomcat(server);
+        }
+    }
+
+    public async browseServer(tomcatServer: TomcatServer): Promise<void> {
+        if (tomcatServer) {
+            const httpPort: string = await Utility.getPort(tomcatServer.getServerConfigPath(), Constants.PortKind.Http);
+            Utility.browse(true, httpPort);
+        }
+    }
+
+    public dispose(): void {
+        this.stopServers();
+        this._tomcatModel.saveServerListSync();
+        this._tomcatModel.getServerSet().forEach((element: TomcatServer) => {
+            element.outputChannel.dispose();
+        });
+    }
+
+    private async selectServer(createIfNoneServer: boolean = false): Promise<TomcatServer> {
+        let items: vscode.QuickPickItem[] = this._tomcatModel.getServerSet();
+        if ((!items || items.length <= 0) && !createIfNoneServer) {
+            return;
+        }
+        items = createIfNoneServer ? items.concat({ label: `$(plus) ${DialogMessage.createServer}`, description: '' }) : items;
+        const pick: vscode.QuickPickItem = await vscode.window.showQuickPick(
+            items,
+            { placeHolder: items && items.length > 0 ? DialogMessage.selectServer : DialogMessage.createServer }
+        );
+
+        if (pick) {
+            if (pick instanceof TomcatServer) {
+                return pick;
+            } else {
+                return await this.createServer();
+            }
         }
     }
 
@@ -242,16 +272,7 @@ export class TomcatController {
         setTimeout(() => vscode.debug.startDebugging(server.getDebugWorkspace(), config), 500);
     }
 
-    private async getServerUri(serverInfo: TomcatServer, appName?: string): Promise<string> {
-        const serverPort: string = await Utility.getPort(serverInfo.getServerConfigPath(), Constants.PortKind.Http);
-        if (!serverPort) {
-            throw new Error('No http port found in server.xml');
-        }
-        // tslint:disable-next-line:no-http-string
-        return `http://localhost:${serverPort}/${appName ? appName : ''}`;
-    }
-
-    private async startTomcat(serverInfo: TomcatServer, appName: string): Promise<void> {
+    private async startTomcat(serverInfo: TomcatServer): Promise<void> {
         const serverName: string = serverInfo.getName();
         let watcher: chokidar.FSWatcher;
         const serverConfig: string = serverInfo.getServerConfigPath();
@@ -266,17 +287,17 @@ export class TomcatController {
                     const result: MessageItem = await vscode.window.showErrorMessage(
                         DialogMessage.getServerPortChangeErrorMessage(serverName, serverPort), DialogMessage.yes, DialogMessage.no, DialogMessage.moreInfo
                     );
+
                     if (result === DialogMessage.yes) {
                         await Utility.setPort(serverConfig, Constants.PortKind.Server, serverPort);
                     } else if (result === DialogMessage.moreInfo) {
-                        opn(Constants.UNABLE_SHUTDOWN_URL);
+                        Utility.browse(false, undefined, undefined, Constants.UNABLE_SHUTDOWN_URL);
                     }
-                } else if (Utility.getRestartConfig() && (httpPort !== await Utility.getPort(serverConfig, Constants.PortKind.Http) ||
-                    httpsPort !== await Utility.getPort(serverConfig, Constants.PortKind.Https))
-                ) {
+                } else if (await Utility.needRestart(httpPort, httpsPort, serverConfig)) {
                     const item: MessageItem = await vscode.window.showInformationMessage(
                         DialogMessage.getConfigChangedMessage(serverName), DialogMessage.yes, DialogMessage.no, DialogMessage.never
                     );
+
                     if (item === DialogMessage.yes) {
                         await this.stopOrRestartServer(serverInfo, true);
                     } else if (item === DialogMessage.never) {
@@ -293,12 +314,23 @@ export class TomcatController {
             watcher.close();
             if (serverInfo.needRestart) {
                 serverInfo.needRestart = false;
-                await this.startTomcat(serverInfo, appName);
+                await this.startTomcat(serverInfo);
             }
         } catch (err) {
             serverInfo.setStarted(false);
             if (watcher) { watcher.close(); }
             throw new Error(err.toString());
         }
+    }
+    private async precheck(tomcatServer: TomcatServer): Promise<TomcatServer> {
+        if (!this._tomcatModel.getServerSet() || this._tomcatModel.getServerSet().length <= 0) {
+            vscode.window.showInformationMessage(DialogMessage.noServer);
+            return;
+        }
+        const server: TomcatServer = tomcatServer ? tomcatServer : await this.selectServer();
+        if (!server) {
+            return;
+        }
+        return server;
     }
 }

--- a/src/Tomcat/TomcatModel.ts
+++ b/src/Tomcat/TomcatModel.ts
@@ -2,6 +2,7 @@
 
 import * as fse from "fs-extra";
 import * as path from "path";
+import * as vscode from "vscode";
 import { TomcatServer } from "./TomcatServer";
 
 export class TomcatModel {
@@ -26,6 +27,7 @@ export class TomcatModel {
             await fse.outputJson(this._serversJsonFile, this._serverList.map((s: TomcatServer) => {
                 return { _name: s.getName(), _installPath: s.getInstallPath(), _storagePath: s.getStoragePath() };
             }));
+            vscode.commands.executeCommand('tomcat.tree.refresh');
         } catch (err) {
             console.error(err.toString());
         }
@@ -38,6 +40,7 @@ export class TomcatModel {
             if (oldServer.length > 0) {
                 fse.remove(tomcatServer.getStoragePath());
                 this.saveServerList();
+                tomcatServer.outputChannel.dispose();
                 return true;
             }
         }

--- a/src/Tomcat/TomcatServer.ts
+++ b/src/Tomcat/TomcatServer.ts
@@ -7,7 +7,6 @@ import { Utility } from "../Utility";
 
 export class TomcatServer extends vscode.TreeItem implements vscode.QuickPickItem {
     public needRestart: boolean = false;
-    public newCreated: boolean = false;
     public label: string;
     public description: string;
     public outputChannel: vscode.OutputChannel;
@@ -59,7 +58,7 @@ export class TomcatServer extends vscode.TreeItem implements vscode.QuickPickIte
 
     public rename(newName: string): void {
         this._name = newName;
-        this.label = this._name;
+        this.label = newName;
     }
 
     public getInstallPath(): string {
@@ -72,9 +71,5 @@ export class TomcatServer extends vscode.TreeItem implements vscode.QuickPickIte
 
     public getStoragePath(): string {
         return this._storagePath;
-    }
-
-    public updateStoragePath(newPath: string): void {
-        this._storagePath = newPath;
     }
 }

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -53,7 +53,7 @@ export namespace Utility {
     export function browse(localhost: boolean, port: string, subPath?: string, url?: string): void {
         if (localhost) {
             // tslint:disable-next-line:no-http-string
-            opn(`http://localhost:${port}/${subPath ? subPath : ''}`);
+            opn(`http://localhost:${port}/${subPath || ''}`);
         } else {
             opn(url);
         }
@@ -92,13 +92,12 @@ export namespace Utility {
     }
 
     export async function validateInstallPath(installPath: string): Promise<boolean> {
-        const serverConfigFile: string = path.join(installPath, 'conf', 'server.xml');
-        const serverWebFile: string = path.join(installPath, 'conf', 'web.xml');
-        const serverBootstrapJarFile: string = path.join(installPath, 'bin', 'bootstrap.jar');
-        const serverJuliJarFile: string = path.join(installPath, 'bin', 'tomcat-juli.jar');
+        const configFileExists: boolean = await fse.pathExists(path.join(installPath, 'conf', 'server.xml'));
+        const serverWebFileExists: boolean = await fse.pathExists(path.join(installPath, 'conf', 'web.xml'));
+        const serverBootstrapJarFileExists: boolean = await fse.pathExists(path.join(installPath, 'bin', 'bootstrap.jar'));
+        const serverJuliJarFileExists: boolean = await fse.pathExists(path.join(installPath, 'bin', 'tomcat-juli.jar'));
 
-        return (!await fse.pathExists(serverConfigFile) || !await fse.pathExists(serverWebFile) ||
-            !await fse.pathExists(serverBootstrapJarFile) || !await fse.pathExists(serverJuliJarFile));
+        return configFileExists && serverWebFileExists && serverBootstrapJarFileExists && serverJuliJarFileExists;
     }
 
     export async function needRestart(httpPort: string, httpsPort: string, serverConfog: string): Promise<boolean> {

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -92,12 +92,12 @@ export namespace Utility {
     }
 
     export async function validateInstallPath(installPath: string): Promise<boolean> {
-        const configFileExists: boolean = await fse.pathExists(path.join(installPath, 'conf', 'server.xml'));
-        const serverWebFileExists: boolean = await fse.pathExists(path.join(installPath, 'conf', 'web.xml'));
-        const serverBootstrapJarFileExists: boolean = await fse.pathExists(path.join(installPath, 'bin', 'bootstrap.jar'));
-        const serverJuliJarFileExists: boolean = await fse.pathExists(path.join(installPath, 'bin', 'tomcat-juli.jar'));
+        const configFileExists: Promise<boolean> = fse.pathExists(path.join(installPath, 'conf', 'server.xml'));
+        const serverWebFileExists: Promise<boolean> = fse.pathExists(path.join(installPath, 'conf', 'web.xml'));
+        const serverBootstrapJarFileExists: Promise<boolean> = fse.pathExists(path.join(installPath, 'bin', 'bootstrap.jar'));
+        const serverJuliJarFileExists: Promise<boolean> = fse.pathExists(path.join(installPath, 'bin', 'tomcat-juli.jar'));
 
-        return configFileExists && serverWebFileExists && serverBootstrapJarFileExists && serverJuliJarFileExists;
+        return await configFileExists && await serverWebFileExists && await serverBootstrapJarFileExists && await serverJuliJarFileExists;
     }
 
     export async function needRestart(httpPort: string, httpsPort: string, serverConfog: string): Promise<boolean> {

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -3,6 +3,8 @@
 import * as child_process from "child_process";
 import * as fse from "fs-extra";
 import * as net from "net";
+// tslint:disable-next-line:no-require-imports
+import opn = require("opn");
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -48,20 +50,21 @@ export namespace Utility {
         }
     }
 
-    export function getRestartConfig(): boolean {
-        const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('tomcat');
-        if (config) {
-            return config.get<boolean>(Constants.RESTART_CONFIG_ID);
+    export function browse(localhost: boolean, port: string, subPath?: string, url?: string): void {
+        if (localhost) {
+            // tslint:disable-next-line:no-http-string
+            opn(`http://localhost:${port}/${subPath ? subPath : ''}`);
+        } else {
+            opn(url);
         }
-        return false;
     }
 
-    export function getServerStoragePath(defaultStoragePath: string, serverName: string): string {
-        return path.join(getWorkspace(defaultStoragePath), serverName);
+    export async function getServerStoragePath(defaultStoragePath: string, serverName: string): Promise<string> {
+        return path.join(await getWorkspace(defaultStoragePath), serverName);
     }
 
     export async function getServerName(installPath: string, defaultStoragePath: string): Promise<string> {
-        const workspace: string = getWorkspace(defaultStoragePath);
+        const workspace: string = await getWorkspace(defaultStoragePath);
         await fse.ensureDir(workspace);
         const fileNames: string[] = await fse.readdir(workspace);
         let serverName: string = path.basename(installPath);
@@ -73,16 +76,40 @@ export namespace Utility {
         return serverName;
     }
 
-    function getWorkspace(defaultStoragePath: string): string {
+    async function getWorkspace(defaultStoragePath: string): Promise<string> {
         const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('tomcat');
         if (config) {
             // tslint:disable-next-line:no-backbone-get-set-outside-model
             const workspace: string = config.get<string>('workspace');
-            if (workspace && !workspace.startsWith('<<')) {
+            try {
+                await fse.ensureDir(workspace);
                 return workspace;
+            } catch (err) {
+                return path.join(defaultStoragePath, 'tomcat');
             }
         }
         return path.join(defaultStoragePath, 'tomcat');
+    }
+
+    export async function validateInstallPath(installPath: string): Promise<boolean> {
+        const serverConfigFile: string = path.join(installPath, 'conf', 'server.xml');
+        const serverWebFile: string = path.join(installPath, 'conf', 'web.xml');
+        const serverBootstrapJarFile: string = path.join(installPath, 'bin', 'bootstrap.jar');
+        const serverJuliJarFile: string = path.join(installPath, 'bin', 'tomcat-juli.jar');
+
+        return (!await fse.pathExists(serverConfigFile) || !await fse.pathExists(serverWebFile) ||
+            !await fse.pathExists(serverBootstrapJarFile) || !await fse.pathExists(serverJuliJarFile));
+    }
+
+    export async function needRestart(httpPort: string, httpsPort: string, serverConfog: string): Promise<boolean> {
+        const newHttpPort: string = await getPort(serverConfog, Constants.PortKind.Http);
+        const newHttpsPort: string = await getPort(serverConfog, Constants.PortKind.Https);
+        let restartConfig: boolean = false;
+        const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('tomcat');
+        if (config) {
+            restartConfig = config.get<boolean>(Constants.RESTART_CONFIG_ID);
+        }
+        return restartConfig && (httpPort !== newHttpPort || httpsPort !== newHttpsPort);
     }
 
     export function getTempStoragePath(): string {

--- a/test/Tomcat.test.ts
+++ b/test/Tomcat.test.ts
@@ -20,7 +20,7 @@ suite('Error input', () => {
   });
   test('runOnServer', async () => {
     try {
-      await tomcatModel.runOnServer(serverInfo, '');
+      await tomcatModel.runOrDebugOnServer();
     } catch (error) {
       assert.equal(error.toString(), `Error: ${DialogMessage.noServer}`);
     }


### PR DESCRIPTION
* commands functions wrap in extension.ts add multiple duplicate checking and same code snippets, move commands logic to tomcatController.ts for clear code style and better maintainess

* move rename server logic to TomcatModel

* let TomcatModel refresh the tree view whenever sever list update

* remove unused variables

* add duplicate commands to make context command title short and clean