### PR TITLE
process server.xml to format and remove comments

### DIFF
--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -85,7 +85,7 @@ export class TomcatController {
         const catalinaBasePath: string = Utility.getServerStoragePath(this._tomcatModel.defaultStoragePath, serverName);
         await fse.remove(catalinaBasePath);
         await Promise.all([
-            fse.copy(serverConfigFile, path.join(catalinaBasePath, 'conf', 'server.xml')),
+            Utility.copyServerConfig(serverConfigFile,  path.join(catalinaBasePath, 'conf', 'server.xml')),
             fse.copy(serverWebFile, path.join(catalinaBasePath, 'conf', 'web.xml')),
             fse.copy(path.join(this._extensionPath, 'resources', 'index.jsp'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'index.jsp')),
             fse.copy(path.join(this._extensionPath, 'resources', 'icon.png'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'icon.png')),

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -74,7 +74,7 @@ export class TomcatController {
         const catalinaBasePath: string = await Utility.getServerStoragePath(this._tomcatModel.defaultStoragePath, serverName);
         await fse.remove(catalinaBasePath);
         await Promise.all([
-            Utility.copyServerConfig(serverConfigFile,  path.join(catalinaBasePath, 'conf', 'server.xml')),
+            Utility.copyServerConfig(path.join(tomcatInstallPath, 'conf', 'server.xml'),  path.join(catalinaBasePath, 'conf', 'server.xml')),
             fse.copy(path.join(tomcatInstallPath, 'conf', 'web.xml'), path.join(catalinaBasePath, 'conf', 'web.xml')),
             fse.copy(path.join(this._extensionPath, 'resources', 'index.jsp'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'index.jsp')),
             fse.copy(path.join(this._extensionPath, 'resources', 'icon.png'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'icon.png')),

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -15,12 +15,6 @@ import { localize } from './localize';
 
 /* tslint:disable:no-any */
 export namespace Utility {
-    export class UserCancelError extends Error {
-        constructor(op: string) {
-            super(localize('tomcatExt.cancel', '{0} was canceled by user', op));
-        }
-    }
-
     export async function executeCMD(outputPane: vscode.OutputChannel, command: string, options: child_process.SpawnOptions, ...args: string[]): Promise<void> {
         await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
             outputPane.show();
@@ -175,9 +169,7 @@ export namespace Utility {
         const jsonObj: {} = await parseXml(xml);
         const builder: xml2js.Builder = new xml2js.Builder();
         const newXml: string = builder.buildObject(jsonObj);
-        if (!await fse.pathExists(target)) {
-            await fse.createFile(target);
-        }
+        await fse.ensureFile(target);
         await fse.writeFile(target, newXml);
     }
 

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -11,6 +11,7 @@ import * as Constants from "./Constants";
 import { DialogMessage } from "./DialogMessage";
 import { localize } from './localize';
 
+/* tslint:disable:no-any */
 export namespace Utility {
     export class UserCancelError extends Error {
         constructor(op: string) {
@@ -103,7 +104,6 @@ export namespace Utility {
         const xml: string = await fse.readFile(serverXml, 'utf8');
         let port: string;
         try {
-            /* tslint:disable:no-any */
             const jsonObj: any = await parseXml(xml);
             if (kind === Constants.PortKind.Server) {
                 port = jsonObj.Server.$.port;
@@ -118,14 +118,13 @@ export namespace Utility {
             port = undefined;
         }
         return port;
-    }/* tslint:enable:no-any */
+    }
 
     export async function setPort(serverXml: string, kind: Constants.PortKind, value: string): Promise<void> {
         if (!await fse.pathExists(serverXml)) {
             throw new Error(DialogMessage.noServer);
         }
         const xml: string = await fse.readFile(serverXml, 'utf8');
-        /* tslint:disable:no-any */
         const jsonObj: any = await parseXml(xml);
         if (kind === Constants.PortKind.Server) {
             jsonObj.Server.$.port = value;
@@ -143,9 +142,19 @@ export namespace Utility {
         const builder: xml2js.Builder = new xml2js.Builder();
         const newXml: string = builder.buildObject(jsonObj);
         await fse.writeFile(serverXml, newXml);
-    }/* tslint:enable:no-any */
+    }
 
-    /* tslint:disable:no-any */
+    export async function copyServerConfig(source: string, target: string): Promise<void> {
+        const xml: string = await fse.readFile(source, 'utf8');
+        const jsonObj: {} = await parseXml(xml);
+        const builder: xml2js.Builder = new xml2js.Builder();
+        const newXml: string = builder.buildObject(jsonObj);
+        if (!await fse.pathExists(target)) {
+            await fse.createFile(target);
+        }
+        await fse.writeFile(target, newXml);
+    }
+
     async function parseXml(xml: string): Promise<any> {
         return new Promise((resolve: (obj: {}) => void, reject: (e: Error) => void): void => {
             xml2js.parseString(xml, { explicitArray: true }, (err: Error, res: {}) => {
@@ -155,5 +164,5 @@ export namespace Utility {
                 return resolve(res);
             });
         });
-    }/* tslint:enable:no-any */
+    }
 }


### PR DESCRIPTION
xml2js write xml file will not keep the comments. So process server.xml during creating server, then users won't be confused when click 'revert' server port.