### PR TITLE
do not show server name in server home page

### DIFF
--- a/resources/index.jsp
+++ b/resources/index.jsp
@@ -22,9 +22,8 @@
 			File f = new File(file);
 			String webappsPath = f.getParent();
 			File webapps = new File(webappsPath);
-			String serverName = webapps.getParentFile().getName();
 		%>
-			<div class="row"><h2>War Packages Deployed on <%=serverName %>:</h2></div>
+			<div class="row"><h2>War Packages Deployed on this Tomcat Server:</h2></div>
 			<div class="row" style="font-size: 22px;">
 				<ul class="list-group">
 				<%


### PR DESCRIPTION
Renaming tomcat server will not reflect the new name in its folder name. And the folder name was the source from which we get the server name to show in the home page.

Considering the cost and benefit, we decide to just show "War Packages Deployed on this Tomcat Server:" as header in home page.