### PR TITLE
Take into account java.home in place of default jvm defined at system…

### DIFF
--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -20,12 +20,16 @@ import { WarPackage } from "./WarPackage";
 
 export class TomcatController {
 
-    private _javaExec: string ;
+    private _javaExec: string = 'java';
 
     constructor(private _tomcatModel: TomcatModel, private _extensionPath: string) {
-        // tslint:disable-next-line:no-backbone-get-set-outside-model
-        const javaHome: string = vscode.workspace.getConfiguration('java').get('home') ;
-        this._javaExec = `${javaHome}/bin/java` ;
+        // If java.home is defined in workspace configuration use this value for the java executable
+        // else use the path to locate the java executable.
+        if ( vscode.workspace.getConfiguration('java').has('home') === true ) {
+            // tslint:disable-next-line:no-backbone-get-set-outside-model
+            const javaHome: string = vscode.workspace.getConfiguration('java').get('home') ;
+            this._javaExec = `${javaHome}/bin/java` ;
+        }
     }
 
     public async deleteServer(tomcatServer: TomcatServer): Promise<void> {

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -19,12 +19,14 @@ import { TomcatServer } from "./TomcatServer";
 import { WarPackage } from "./WarPackage";
 
 export class TomcatController {
-    constructor(private _tomcatModel: TomcatModel, private _extensionPath: string) {
-        let configuration = vscode.workspace.getConfiguration('java') ;
-        this.javaExec = configuration.get('home') + '/bin/java' ;
-    }
 
-    private javaExec: string ;
+    private _javaExec: string ;
+
+    constructor(private _tomcatModel: TomcatModel, private _extensionPath: string) {
+        // tslint:disable-next-line:no-backbone-get-set-outside-model
+        const javaHome: string = vscode.workspace.getConfiguration('java').get('home') ;
+        this._javaExec = `${javaHome}/bin/java` ;
+    }
 
     public async deleteServer(tomcatServer: TomcatServer): Promise<void> {
         const server: TomcatServer = await this.precheck(tomcatServer);
@@ -159,7 +161,7 @@ export class TomcatController {
                 return;
             }
             Utility.trackTelemetryStep(restart ? 'restart' : 'stop');
-            await Utility.executeCMD(server.outputChannel, this.javaExec, { shell: true }, ...server.jvmOptions.concat('stop'));
+            await Utility.executeCMD(server.outputChannel, this._javaExec, { shell: true }, ...server.jvmOptions.concat('stop'));
             if (!restart) {
                 server.clearDebugInfo();
             }
@@ -348,9 +350,8 @@ export class TomcatController {
                 startArguments = [`${Constants.DEBUG_ARGUMENT_KEY}${serverInfo.getDebugPort()}`].concat(startArguments);
             }
             startArguments.push('start');
-            
 
-            const javaProcess: Promise<void> = Utility.executeCMD(serverInfo.outputChannel, this.javaExec, { shell: true }, ...startArguments);
+            const javaProcess: Promise<void> = Utility.executeCMD(serverInfo.outputChannel, this._javaExec, { shell: true }, ...startArguments);
             serverInfo.setStarted(true);
             this.startDebugSession(serverInfo);
             await javaProcess;

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -20,7 +20,11 @@ import { WarPackage } from "./WarPackage";
 
 export class TomcatController {
     constructor(private _tomcatModel: TomcatModel, private _extensionPath: string) {
+        let configuration = vscode.workspace.getConfiguration('java') ;
+        this.javaExec = configuration.get('home') + '/bin/java' ;
     }
+
+    private javaExec: string ;
 
     public async deleteServer(tomcatServer: TomcatServer): Promise<void> {
         const server: TomcatServer = await this.precheck(tomcatServer);
@@ -155,7 +159,7 @@ export class TomcatController {
                 return;
             }
             Utility.trackTelemetryStep(restart ? 'restart' : 'stop');
-            await Utility.executeCMD(server.outputChannel, 'java', { shell: true }, ...server.jvmOptions.concat('stop'));
+            await Utility.executeCMD(server.outputChannel, this.javaExec, { shell: true }, ...server.jvmOptions.concat('stop'));
             if (!restart) {
                 server.clearDebugInfo();
             }
@@ -344,7 +348,9 @@ export class TomcatController {
                 startArguments = [`${Constants.DEBUG_ARGUMENT_KEY}${serverInfo.getDebugPort()}`].concat(startArguments);
             }
             startArguments.push('start');
-            const javaProcess: Promise<void> = Utility.executeCMD(serverInfo.outputChannel, 'java', { shell: true }, ...startArguments);
+            
+
+            const javaProcess: Promise<void> = Utility.executeCMD(serverInfo.outputChannel, this.javaExec, { shell: true }, ...startArguments);
             serverInfo.setStarted(true);
             this.startDebugSession(serverInfo);
             await javaProcess;


### PR DESCRIPTION
… level

Take into account java.home defined in the java extension configuration (system or workspace level) to launch the tomcat executables. This value replace the path of the jvm (declare in the PATH environment variable at system level).