### PR TITLE
Account for case when looking at context XML.  Issue #218

### DIFF
--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -377,9 +377,12 @@ export class TomcatController {
         if (await fse.pathExists(path.join(folderLocation, 'META-INF', 'context.xml'))) {
             const xml: string = fs.readFileSync(path.join(folderLocation, 'META-INF', 'context.xml'), 'utf8');
             const jsonFromXml: any = await Utility.parseXml(xml);
-            if (jsonFromXml && jsonFromXml.Context && jsonFromXml.Context.$) {
-                const rawPath: string = jsonFromXml.Context.$.path;
-                appName = this.parseContextPathToFolderName(rawPath);
+            if (jsonFromXml) {
+                if (jsonFromXml.Context && jsonFromXml.Context.$) {
+                    appName = this.parseContextPathToFolderName(jsonFromXml.Context.$.path);
+                } else if (jsonFromXml.context && jsonFromXml.context.$) {
+                    appName = this.parseContextPathToFolderName(jsonFromXml.context.$.path);
+                }
             }
         }
         return appName;

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -378,9 +378,9 @@ export class TomcatController {
             const xml: string = fs.readFileSync(path.join(folderLocation, 'META-INF', 'context.xml'), 'utf8');
             const jsonFromXml: any = await Utility.parseXml(xml);
             if (jsonFromXml) {
-                if (jsonFromXml.Context && jsonFromXml.Context.$) {
+                if (jsonFromXml.Context && jsonFromXml.Context.$ && jsonFromXml.Context.$.path) {
                     appName = this.parseContextPathToFolderName(jsonFromXml.Context.$.path);
-                } else if (jsonFromXml.context && jsonFromXml.context.$) {
+                } else if (jsonFromXml.context && jsonFromXml.context.$ && jsonFromXml.context.$.path) {
                     appName = this.parseContextPathToFolderName(jsonFromXml.context.$.path);
                 }
             }


### PR DESCRIPTION
I noticed in the most recent PR for this issue, the code is looking for a document beginning with an uppercase "Context" tag. By default, my team typically uses lowercase "context" for tags.

I have kept the uppercase version as the first search path, but if that fails (in our case it will) we will also check for the downcase version before defaulting to the original app name;