### PR TITLE
Remove version information from app name

### DIFF
--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -356,11 +356,21 @@ export class TomcatController {
 
     /* tslint:disable:no-any */
     private async determineAppName(webappPath: string, server: TomcatServer): Promise<string> {
-        const defaultName: string = path.basename(webappPath, path.extname(webappPath));
-        let appName: string = defaultName;
+        const isWarFile: boolean = this.isWarFile(webappPath);
+
+        let appName: string = isWarFile
+            ? path.basename(webappPath, path.extname(webappPath))
+            : path.basename(webappPath);
+
+        // remove version information from app name if any
+        const versionIndex: number = appName.search(/\-[0-9]+\.[0-9]+/gi);
+        if (versionIndex > -1) {
+            appName = appName.substr(0, versionIndex);
+        }
+
         let folderLocation: string;
-        if (this.isWarFile(webappPath)) {
-            folderLocation = path.join(this._tomcatModel.defaultStoragePath, defaultName);
+        if (isWarFile) {
+            folderLocation = path.join(this._tomcatModel.defaultStoragePath, appName);
             await fse.remove(folderLocation);
             await fse.mkdir(folderLocation);
             await Utility.executeCMD(this._outputChannel, server.getName(), 'jar', { cwd: folderLocation }, 'xvf', `${webappPath}`);


### PR DESCRIPTION
If the war archive or exploded war folder contains version information, it should be removed from the app name.

* `my-app-1.0-SNAPSHOT` becomes `my-app`
* `my-app-1.0` becomes `my-app`