### PR TITLE
Added 'debug default target' functionality, along with some niceties for quick debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
             "default": true,
             "description": "Restart Tomcat Server or not when http(s) port changes"
           },
-          "tomcat.defaultDebugTarget": {
+          "tomcat.debug.defaultTarget": {
             "type": "string",
             "default": "",
             "description": "Default war to load for debugging"

--- a/package.json
+++ b/package.json
@@ -359,6 +359,16 @@
             "type": "string",
             "default": "",
             "description": "Default war to load for debugging"
+          },
+          "tomcat.debug.webAddressToOpen": {
+            "type": "string",
+            "default": "",
+            "description": "If set, will open this webpage in default browser when debugging"
+          },
+          "tomcat.debug.preLaunchTask": {
+            "type": "string",
+            "default": "",
+            "description": "Same as preLaunchTask for debug."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "aiKey": "174d54c8-21db-4808-8a41-1ddb08d97147",
   "icon": "resources/icon.png",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.31.0"
   },
   "repository": {
     "type": "git",
@@ -63,6 +63,11 @@
           "light": "resources/light/add.svg",
           "dark": "resources/dark/add.svg"
         }
+      },
+      {
+        "command": "tomcat.server.defaultDebug",
+        "title": "Debug default war on server",
+        "category": "Tomcat"
       },
       {
         "command": "tomcat.war.run",
@@ -349,6 +354,11 @@
             "type": "boolean",
             "default": true,
             "description": "Restart Tomcat Server or not when http(s) port changes"
+          },
+          "tomcat.defaultDebugTarget": {
+            "type": "string",
+            "default": "",
+            "description": "Default war to load for debugging"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         }
       },
       {
-        "command": "tomcat.server.defaultDebug",
+        "command": "tomcat.server.debugDefault",
         "title": "Debug default war on server",
         "category": "Tomcat"
       },

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -183,7 +183,7 @@ export class TomcatController {
     public async debugDefaultOnServer(server?: TomcatServer) {
         // get default debug target from configuration
         console.log("Starting a default debug session");
-        let confPath = vscode.workspace.getConfiguration("tomcat").get<string>("defaultDebugTarget");
+        let confPath = vscode.workspace.getConfiguration("tomcat").get<string>("debug.defaultTarget");
         console.log("getting uri from workspace configuration: ${confPath}");
         let uri = (await vscode.workspace.findFiles(confPath))[0];
         if (uri == undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     context.subscriptions.push(registerCommandWrapper('tomcat.server.delete', (server: TomcatServer) => tomcatController.deleteServer(server)));
     context.subscriptions.push(registerCommandWrapper('tomcat.server.browse', (server: TomcatServer) => tomcatController.browseServer(server)));
     context.subscriptions.push(registerCommandWrapper('tomcat.server.debug', (server: TomcatServer) => tomcatController.runOrDebugOnServer(undefined, true, server)));
-    context.subscriptions.push(registerCommandWrapper('tomcat.server.defaultDebug', () => tomcatController.debugDefaultOnServer()));
+    context.subscriptions.push(registerCommandWrapper('tomcat.server.debugDefault', () => tomcatController.debugDefaultOnServer()));
     context.subscriptions.push(registerCommandWrapper('tomcat.war.run', (uri: vscode.Uri) => tomcatController.runOrDebugOnServer(uri)));
     context.subscriptions.push(registerCommandWrapper('tomcat.war.debug', (uri: vscode.Uri) => tomcatController.runOrDebugOnServer(uri, true)));
     context.subscriptions.push(registerCommandWrapper('tomcat.webapp.run', (uri: vscode.Uri) => tomcatController.runOrDebugOnServer(uri)));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     context.subscriptions.push(registerCommandWrapper('tomcat.server.delete', (server: TomcatServer) => tomcatController.deleteServer(server)));
     context.subscriptions.push(registerCommandWrapper('tomcat.server.browse', (server: TomcatServer) => tomcatController.browseServer(server)));
     context.subscriptions.push(registerCommandWrapper('tomcat.server.debug', (server: TomcatServer) => tomcatController.runOrDebugOnServer(undefined, true, server)));
+    context.subscriptions.push(registerCommandWrapper('tomcat.server.defaultDebug', () => tomcatController.debugDefaultOnServer()));
     context.subscriptions.push(registerCommandWrapper('tomcat.war.run', (uri: vscode.Uri) => tomcatController.runOrDebugOnServer(uri)));
     context.subscriptions.push(registerCommandWrapper('tomcat.war.debug', (uri: vscode.Uri) => tomcatController.runOrDebugOnServer(uri, true)));
     context.subscriptions.push(registerCommandWrapper('tomcat.webapp.run', (uri: vscode.Uri) => tomcatController.runOrDebugOnServer(uri)));


### PR DESCRIPTION
Added quick (and dirty) way to define a default debug target and to quickly launch it.

I'm using this extention for develloping a JEE application but i'm tired of manually selecting a war to debug, so I added a small functionality to load a predefined (default) .war indicated in workspace config. I also added option to automatically open a webpage and a way to set `preLaunchTask` option for built-in debug configuration.

There's also a small problem with replacing .war's on the server in debug mode. Current workaround is to stop server when `tomcat.server.debugDefault` command is called.