### PR TITLE
Update README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 * [Apache Tomcat](http://tomcat.apache.org/)
 * [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) (for debuging war package)
 
-If you are a Windows user, you should add the bin subdirectory of your JDK installation to your user-level or system PATH environment variable.
+If you are a Windows user, you should add the bin subdirectory of your JDK installation to your PATH environment variable (User or System) and restart VS Code. This is required to debug/run war packages from the VS Code context menu.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 * [Apache Tomcat](http://tomcat.apache.org/)
 * [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) (for debuging war package)
 
+If you are a Windows user, you should add the bin subdirectory of your JDK installation to your user-level environment variables.
+
 ## Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 * [Apache Tomcat](http://tomcat.apache.org/)
 * [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) (for debuging war package)
 
-If you are a Windows user, you should add the bin subdirectory of your JDK installation to your user-level environment variables.
+If you are a Windows user, you should add the bin subdirectory of your JDK installation to your user-level or system PATH environment variable.
 
 ## Contributing
 


### PR DESCRIPTION
Tell Windows users about necessary path changes for WAR deployment to work. The same issue keeps getting opened up multiple times (see #273 as the most recent), so having this information in the README may help.