### PR TITLE
Add funtion to get java path

### DIFF
--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -157,7 +157,7 @@ export class TomcatController {
             }
             server.needRestart = restart;
             await Utility.trackTelemetryStep(operationId, restart ? 'restart' : 'stop', () =>
-                Utility.executeCMD(this._outputChannel, server.getName(), 'java', { shell: true }, ...server.jvmOptions.concat('stop')));
+                Utility.executeCMD(this._outputChannel, server.getName(), Utility.getJavaExecutable(), { shell: true }, ...server.jvmOptions.concat('stop')));
         }
     }
 
@@ -450,7 +450,7 @@ export class TomcatController {
                 startArguments = [`${Constants.DEBUG_ARGUMENT_KEY}${serverInfo.getDebugPort()}`].concat(startArguments);
             }
             startArguments.push('start');
-            const javaProcess: Promise<void> = Utility.executeCMD(this._outputChannel, serverInfo.getName(), 'java', { shell: true }, ...startArguments);
+            const javaProcess: Promise<void> = Utility.executeCMD(this._outputChannel, serverInfo.getName(), Utility.getJavaExecutable(), { shell: true }, ...startArguments);
             serverInfo.setStarted(true);
             this.startDebugSession(operationId, serverInfo);
             await javaProcess;

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -205,4 +205,13 @@ export namespace Utility {
             });
         });
     }
+
+    export function getJavaExecutable(): string {
+        let javaPath = '';
+        const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('java');
+        if (config) {
+            javaPath = config.get<string>('home');
+        }
+        return javaPath ? javaPath + '/bin/java' : 'java';
+    }
 }


### PR DESCRIPTION
I had problems running npm test, but the idea is that I can use the workspace specific java version so I don't have to change PATH every time I need to run a different java version