### PR TITLE
Fixed linux tomcat server adding issue. Fixes #226

### DIFF
--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -105,7 +105,7 @@ export class TomcatController {
         await fse.remove(catalinaBasePath);
         Utility.trackTelemetryStep('copy files');
         await Promise.all([
-            fse.copy(path.join(tomcatInstallPath, 'conf'), path.join(catalinaBasePath, 'conf')),
+            fse.copy(path.join(tomcatInstallPath, 'conf'), path.join(catalinaBasePath, 'conf'), {dereference: true}),
             fse.copy(path.join(this._extensionPath, 'resources', 'jvm.options'), path.join(catalinaBasePath, 'jvm.options')),
             fse.copy(path.join(this._extensionPath, 'resources', 'index.jsp'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'index.jsp')),
             fse.copy(path.join(this._extensionPath, 'resources', 'icon.png'), path.join(catalinaBasePath, 'webapps', 'ROOT', 'icon.png')),


### PR DESCRIPTION
This issue was caused by a file permission issue. Error will throwing on [this](https://github.com/adashen/vscode-tomcat/blob/427a0431488406c4c4634da6a932764ce1f5b6a1/src/Utility.ts#L198) line. fs-extra copy function will symlinking files by default. The permissions of the `/usr/share/tomcat<number>/` folder will apply when symlinking.