### PR TITLE
Delete confirmation popup should show always 

### DIFF
--- a/src/DialogMessage.ts
+++ b/src/DialogMessage.ts
@@ -16,7 +16,7 @@ export namespace DialogMessage {
     export const noServerConfig: string = localize('tomcatExt.noServerConfig', 'The Tomcat Server is broken. It does not have server.xml');
     export const selectWarPackage: string = localize('tomcatExt.selectWarPackage', 'Select War Package');
     export const selectDirectory: string = localize('tomcatExt.selectDirectory', 'Select Tomcat Directory');
-    export const deleteConfirm: string = localize('tomcatExt.deleteConfirm', 'This Tomcat Server is running, are you sure you want to delete it?');
+    export const deleteConfirm: string = localize('tomcatExt.deleteConfirm', 'Are you sure you want to delete this server?');
     export const serverRunning: string = localize('tomcatExt.serverRunning', 'This Tomcat Server is already started.');
     export const serverStopped: string = localize('tomcatExt.serverStopped', 'This Tomcat Server was stopped.');
     export const startServer: string = localize('tomcatExt.startServer', 'The Tomcat server needs to be started before browsing. Would you like to start it now?');

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -33,7 +33,9 @@ export class TomcatController {
                 Utility.infoTelemetryStep(operationId, 'cancel');
                 return;
             }
-            await this.stopOrRestartServer(operationId, server);
+            if (server.isStarted()) {
+                await this.stopOrRestartServer(operationId, server);
+            }
             this._tomcatModel.deleteServer(server);
         }
     }

--- a/src/Tomcat/TomcatController.ts
+++ b/src/Tomcat/TomcatController.ts
@@ -28,14 +28,12 @@ export class TomcatController {
     public async deleteServer(operationId: string, tomcatServer: TomcatServer): Promise<void> {
         const server: TomcatServer = await this.precheck(operationId, tomcatServer);
         if (server) {
-            if (server.isStarted()) {
-                const confirmation: MessageItem = await vscode.window.showWarningMessage(DialogMessage.deleteConfirm, DialogMessage.yes, DialogMessage.cancel);
-                if (confirmation !== DialogMessage.yes) {
-                    Utility.infoTelemetryStep(operationId, 'cancel');
-                    return;
-                }
-                await this.stopOrRestartServer(operationId, server);
+            const confirmation: MessageItem = await vscode.window.showWarningMessage(DialogMessage.deleteConfirm, DialogMessage.yes, DialogMessage.cancel);
+            if (confirmation !== DialogMessage.yes) {
+                Utility.infoTelemetryStep(operationId, 'cancel');
+                return;
             }
+            await this.stopOrRestartServer(operationId, server);
             this._tomcatModel.deleteServer(server);
         }
     }


### PR DESCRIPTION
Delete confirmation popup should show always when user clicks a "Delete" option.
Many colleagues trying to click "Debug war package" by accident select the "Delete" option and this deletes the server and all config defined there.