### PR TITLE
Modify to return the correct java path even if the directory name contains spaces

### DIFF
--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -212,6 +212,6 @@ export namespace Utility {
         if (config) {
             javaPath = config.get<string>('home');
         }
-        return javaPath ? javaPath + '/bin/java' : 'java';
+        return javaPath ? "\"" + javaPath + '/bin/java' + "\"" : 'java';
     }
 }


### PR DESCRIPTION
i use chocolatey on my windows pc. chocolatey is package manager.
when openjdk is installed, it's directory name contains spaces. when i set vscode's settings.json, `java.home` contains spaces, same.
then vscode-tomcat can't up, because command `java` divide by spaces.

i add double-quote when return path command `java`,  using by `java.home`.